### PR TITLE
feat: Implement storing and showing status

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,10 +4,14 @@
 	<name>Integration Documenso</name>
 	<summary>Sign files via Documenso Service.</summary>
 	<description>Sign files via Documenso Service.</description>
-	<version>2.3.0-dev.1</version>
+	<version>2.3.0-dev.2</version>
 	<licence>agpl</licence>
 	<author mail="jana.peper@nextcloud.com">Jana Peper</author>
 	<namespace>Documenso</namespace>
+	<types>
+		<filesystem/>
+		<dav/>
+	</types>
 	<category>files</category>
 	<category>workflow</category>
 	<website>https://github.com/nextcloud/integration_documenso</website>

--- a/img/dash_cancelled.svg
+++ b/img/dash_cancelled.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   height="24"
+   width="24"
+   version="1.1"
+   viewBox="0 0 24 24">
+  <path
+     d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4M8,11H16V13H8V11Z"
+     style="stroke:#cee2ed;fill:#141b23;stroke-opacity:1;paint-order:stroke fill markers;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round" />
+</svg>

--- a/img/dash_rejected.svg
+++ b/img/dash_rejected.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   height="24"
+   width="24"
+   version="1.1"
+   viewBox="0 0 24 24">
+  <path
+     d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+     style="stroke:#cee2ed;fill:#141b23;stroke-opacity:1;paint-order:stroke fill markers;stroke-width:2.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round" />
+</svg>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace OCA\Documenso\AppInfo;
 
+use OCA\DAV\Events\SabrePluginAddEvent;
 use OCA\Documenso\Dashboard\DocumensoWidget;
+use OCA\Documenso\Dav\DocumensoPlugin;
 use OCA\Documenso\Listener\ContentSecurityPolicyListener;
+use OCA\Documenso\Listener\NodeDeletedListener;
 use OCA\Documenso\Notification\Notifier;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCP\AppFramework\App;
@@ -13,11 +16,13 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCP\Util;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'integration_documenso';
+	public const DAV_PROPERTY_DOCUMENSO_STATE = '{http://nextcloud.org/ns}documenso-state';
 
 	/** @psalm-suppress PossiblyUnusedMethod */
 	public function __construct(array $urlParams = []) {
@@ -27,18 +32,24 @@ class Application extends App implements IBootstrap {
 
 		/** @var IEventDispatcher $eventDispatcher */
 		$eventDispatcher = $container->get(IEventDispatcher::class);
-		// load files plugin script
 		$eventDispatcher->addListener(LoadAdditionalScriptsEvent::class, function () {
-			Util::addscript(self::APP_ID, self::APP_ID . '-filesplugin');
+			Util::addInitScript(self::APP_ID, self::APP_ID . '-init');
+			Util::addScript(self::APP_ID, self::APP_ID . '-filesplugin');
 		});
 	}
 
 	public function register(IRegistrationContext $context): void {
 		$context->registerDashboardWidget(DocumensoWidget::class);
 		$context->registerEventListener(AddContentSecurityPolicyEvent::class, ContentSecurityPolicyListener::class);
+		$context->registerEventListener(NodeDeletedEvent::class, NodeDeletedListener::class);
 		$context->registerNotifierService(Notifier::class);
 	}
 
 	public function boot(IBootContext $context): void {
+		$eventDispatcher = $context->getServerContainer()->get(IEventDispatcher::class);
+		$eventDispatcher->addListener(SabrePluginAddEvent::class, function (SabrePluginAddEvent $event) use ($context): void {
+			$plugin = $context->getAppContainer()->get(DocumensoPlugin::class);
+			$event->getServer()->addPlugin($plugin);
+		});
 	}
 }

--- a/lib/BackgroundJob/CheckUserDocumentsJob.php
+++ b/lib/BackgroundJob/CheckUserDocumentsJob.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Documenso\BackgroundJob;
 
 use OCA\Documenso\AppInfo\Application;
+use OCA\Documenso\Db\DocumensoFile;
 use OCA\Documenso\Db\DocumensoFileMapper;
 use OCA\Documenso\Service\FileService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -50,7 +51,8 @@ class CheckUserDocumentsJob extends QueuedJob {
 			return;
 		}
 
-		$mappings = $this->fileMapper->findAllByUserId($userId);
+		$pollStatuses = [DocumensoFile::STATUS_DRAFT, DocumensoFile::STATUS_PENDING];
+		$mappings = $this->fileMapper->findByUserIdAndStatuses($userId, $pollStatuses);
 		if ($mappings === []) {
 			return;
 		}
@@ -59,7 +61,7 @@ class CheckUserDocumentsJob extends QueuedJob {
 			$this->fileService->processMapping($mapping);
 		}
 
-		if ($this->fileMapper->findAllByUserId($userId) !== []) {
+		if ($this->fileMapper->findByUserIdAndStatuses($userId, $pollStatuses) !== []) {
 			$this->scheduleRetry($userId);
 		}
 	}

--- a/lib/Controller/DocumensoController.php
+++ b/lib/Controller/DocumensoController.php
@@ -6,6 +6,7 @@ namespace OCA\Documenso\Controller;
 
 use OCA\Documenso\AppInfo\Application;
 use OCA\Documenso\BackgroundJob\CheckUserDocumentsJob;
+use OCA\Documenso\Db\DocumensoFile;
 use OCA\Documenso\Db\DocumensoFileMapper;
 use OCA\Documenso\Service\DocumensoAPIService;
 use OCA\Documenso\Service\FileService;
@@ -90,6 +91,15 @@ class DocumensoController extends Controller {
 				return new DataResponse(['error' => 'You don\'t have permission to overwrite the original file'], 401);
 			}
 		}
+		$mapping = $this->documensoFileMapper->findByFileId($fileId);
+		if ($mapping !== null) {
+			$status = $mapping->getStatus();
+			if ($status === DocumensoFile::STATUS_CANCELLED || $status === DocumensoFile::STATUS_REJECTED) {
+				$this->documensoFileMapper->delete($mapping);
+			} else {
+				return new DataResponse(['error' => 'A Documenso signing process has already been started for this file'], 401);
+			}
+		}
 		$signResult = $this->documensoAPIService->emailSignStandalone($fileId, $this->userId, $targetEmails, $targetUserIds);
 		if (isset($signResult['error'])) {
 			return new DataResponse($signResult, 401);
@@ -158,7 +168,10 @@ class DocumensoController extends Controller {
 				$jobArgument = ['user_id' => $this->userId];
 				if ($disabled) {
 					$this->jobList->remove(CheckUserDocumentsJob::class, $jobArgument);
-				} elseif ($this->documensoFileMapper->findAllByUserId($this->userId) !== []
+				} elseif ($this->documensoFileMapper->findByUserIdAndStatuses($this->userId, [
+					DocumensoFile::STATUS_DRAFT,
+					DocumensoFile::STATUS_PENDING,
+				]) !== []
 					&& !$this->jobList->has(CheckUserDocumentsJob::class, $jobArgument)) {
 					$this->jobList->add(CheckUserDocumentsJob::class, $jobArgument);
 				}

--- a/lib/Controller/WebhookController.php
+++ b/lib/Controller/WebhookController.php
@@ -46,7 +46,6 @@ class WebhookController extends Controller {
 	 * Receive Documenso webhook events for a Nextcloud user.
 	 *
 	 * @param string $userId
-	 * @param string|null $event
 	 * @param array|null $payload
 	 * @return DataResponse
 	 */
@@ -54,7 +53,7 @@ class WebhookController extends Controller {
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'documenso_webhook')]
 	#[FrontpageRoute(verb: 'POST', url: '/webhook/{userId}')]
-	public function handle(string $userId, ?string $event = null, ?array $payload = null): DataResponse {
+	public function handle(string $userId, ?array $payload = null): DataResponse {
 		$receivedSecret = $this->request->getHeader('X-Documenso-Secret');
 		$storedSecret = $this->utilsService->getEncryptedUserValue($userId, UtilsService::WEBHOOK_SECRET_KEY);
 		if ($storedSecret === '' || $receivedSecret === '' || !hash_equals($storedSecret, $receivedSecret)) {
@@ -66,19 +65,15 @@ class WebhookController extends Controller {
 		$this->config->setUserValue($userId, Application::APP_ID, 'polling_disabled', '1');
 		$this->jobList->remove(CheckUserDocumentsJob::class, ['user_id' => $userId]);
 
-		if ($event !== 'DOCUMENT_COMPLETED') {
-			return new DataResponse(['received' => true]);
-		}
-
 		$documentId = 0;
 		if (is_array($payload) && isset($payload['id']) && is_numeric($payload['id'])) {
 			$documentId = (int)$payload['id'];
 		}
-		if ($documentId <= 0) {
-			$this->logger->warning(
-				'Documenso webhook DOCUMENT_COMPLETED is missing a document id',
-				['app' => Application::APP_ID]
-			);
+		$hasStatus = is_array($payload)
+			&& isset($payload['status'])
+			&& is_string($payload['status'])
+			&& $payload['status'] !== '';
+		if ($documentId <= 0 || !$hasStatus) {
 			return new DataResponse(['received' => true]);
 		}
 

--- a/lib/Dav/DocumensoPlugin.php
+++ b/lib/Dav/DocumensoPlugin.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Documenso\Dav;
+
+use OCA\DAV\Connector\Sabre\Directory as SabreDirectory;
+use OCA\DAV\Connector\Sabre\Node as SabreNode;
+use OCA\Documenso\AppInfo\Application;
+use OCA\Documenso\Db\DocumensoFileMapper;
+use Sabre\DAV\ICollection;
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+
+class DocumensoPlugin extends ServerPlugin {
+	/** @var array<int, string|null> */
+	private array $cachedStatuses = [];
+	/** @var array<string, true> */
+	private array $cachedDirectories = [];
+
+	public function __construct(
+		private DocumensoFileMapper $fileMapper,
+	) {
+	}
+
+	public function initialize(Server $server): void {
+		$server->on('propFind', [$this, 'propFind']);
+		$server->on('preloadCollection', $this->preloadCollection(...));
+	}
+
+	/**
+	 * @param PropFind $propFind
+	 * @param INode $node
+	 */
+	public function propFind(PropFind $propFind, INode $node) {
+		if (!$node instanceof SabreNode) {
+			return;
+		}
+		$nodeId = $node->getId();
+		$propFind->handle(
+			Application::DAV_PROPERTY_DOCUMENSO_STATE,
+			function () use ($nodeId) {
+				return $this->getStatus($nodeId);
+			}
+		);
+	}
+
+	public function getPluginName(): string {
+		return Application::APP_ID;
+	}
+
+	/**
+	 * @return array{name: string, description: string}
+	 */
+	public function getPluginInfo(): array {
+		return [
+			'name' => $this->getPluginName(),
+			'description' => 'Provides Documenso signing state in PROPFIND WebDAV requests',
+		];
+	}
+
+	/**
+	 * @param PropFind $propFind
+	 * @param ICollection $collection
+	 * @return void
+	 */
+	public function preloadCollection(PropFind $propFind, ICollection $collection): void {
+		if (!($collection instanceof SabreNode)) {
+			return;
+		}
+		if ($collection instanceof SabreDirectory
+			&& !isset($this->cachedDirectories[$collection->getPath()])
+			&& (!is_null($propFind->getStatus(Application::DAV_PROPERTY_DOCUMENSO_STATE)))
+		) {
+			$folderContent = $collection->getChildren();
+			$fileIds = [$collection->getId()];
+			foreach ($folderContent as $info) {
+				$fileIds[] = $info->getId();
+			}
+			$this->preloadStatuses($fileIds);
+			$this->cachedDirectories[$collection->getPath()] = true;
+		}
+	}
+
+	/**
+	 * @param list<int> $fileIds
+	 */
+	private function preloadStatuses(array $fileIds): void {
+		$missing = [];
+		foreach ($fileIds as $fileId) {
+			if (!array_key_exists($fileId, $this->cachedStatuses)) {
+				$missing[] = $fileId;
+			}
+		}
+		if ($missing === []) {
+			return;
+		}
+		$statuses = $this->fileMapper->findStatusesByFileIds($missing);
+		foreach ($missing as $fileId) {
+			$this->cachedStatuses[$fileId] = $statuses[$fileId] ?? null;
+		}
+	}
+
+	private function getStatus(int $fileId): ?string {
+		$this->preloadStatuses([$fileId]);
+		return $this->cachedStatuses[$fileId];
+	}
+}

--- a/lib/Db/DocumensoFile.php
+++ b/lib/Db/DocumensoFile.php
@@ -18,18 +18,37 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDocumentId(int $documentId)
  * @method string getUserId()
  * @method void setUserId(string $userId)
+ * @method string getStatus()
+ * @method void setStatus(string $status)
  */
 class DocumensoFile extends Entity {
+	public const STATUS_DRAFT = 'DRAFT';
+	public const STATUS_PENDING = 'PENDING';
+	public const STATUS_COMPLETED = 'COMPLETED';
+	public const STATUS_REJECTED = 'REJECTED';
+	public const STATUS_CANCELLED = 'CANCELLED';
+
+	public const STATUSES = [
+		self::STATUS_DRAFT,
+		self::STATUS_PENDING,
+		self::STATUS_COMPLETED,
+		self::STATUS_REJECTED,
+		self::STATUS_CANCELLED,
+	];
+
 	/** @var int */
 	protected $fileId;
 	/** @var int */
 	protected $documentId;
 	/** @var string */
 	protected $userId;
+	/** @var string */
+	protected $status;
 
 	public function __construct() {
 		$this->addType('fileId', 'integer');
 		$this->addType('documentId', 'integer');
 		$this->addType('userId', 'string');
+		$this->addType('status', 'string');
 	}
 }

--- a/lib/Db/DocumensoFileMapper.php
+++ b/lib/Db/DocumensoFileMapper.php
@@ -40,17 +40,61 @@ class DocumensoFileMapper extends QBMapper {
 	}
 
 	/**
-	 * @return list<DocumensoFile>
+	 * @throws MultipleObjectsReturnedException
 	 * @throws Exception
 	 */
-	public function findAllByUserId(string $userId): array {
+	public function findByFileId(int $fileId): ?DocumensoFile {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)));
+			->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+
+		try {
+			return $this->findEntity($qb);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}
+
+	/**
+	 * @param list<string> $statuses
+	 * @return list<DocumensoFile>
+	 * @throws Exception
+	 */
+	public function findByUserIdAndStatuses(string $userId, array $statuses): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->in('status', $qb->createNamedParameter($statuses, IQueryBuilder::PARAM_STR_ARRAY)));
 
 		/** @var list<DocumensoFile> */
 		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @param list<int> $fileIds
+	 * @return array<int, string> fileId => status
+	 * @throws Exception
+	 */
+	public function findStatusesByFileIds(array $fileIds): array {
+		if ($fileIds === []) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('file_id', 'status')
+			->from($this->getTableName())
+			->where($qb->expr()->in('file_id', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
+
+		$result = [];
+		foreach ($qb->executeQuery()->fetchAll() as $row) {
+			$fileId = (int)$row['file_id'];
+			if (!isset($result[$fileId]) && is_string($row['status'])) {
+				$result[$fileId] = $row['status'];
+			}
+		}
+		return $result;
 	}
 
 	/**
@@ -61,6 +105,7 @@ class DocumensoFileMapper extends QBMapper {
 		$entity->setFileId($fileId);
 		$entity->setDocumentId($documentId);
 		$entity->setUserId($userId);
+		$entity->setStatus(DocumensoFile::STATUS_DRAFT);
 		return $this->insert($entity);
 	}
 }

--- a/lib/Listener/NodeDeletedListener.php
+++ b/lib/Listener/NodeDeletedListener.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Documenso\Listener;
+
+use OCA\Documenso\AppInfo\Application;
+use OCA\Documenso\Db\DocumensoFileMapper;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\Node\NodeDeletedEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<NodeDeletedEvent>
+ */
+class NodeDeletedListener implements IEventListener {
+
+	public function __construct(
+		private DocumensoFileMapper $fileMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function handle(Event $event): void {
+		if (!$event instanceof NodeDeletedEvent) {
+			return;
+		}
+
+		try {
+			$fileId = $event->getNode()->getId();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'Failed to get node id on delete for Documenso cleanup: ' . $e->getMessage(),
+				['app' => Application::APP_ID, 'exception' => $e]
+			);
+			return;
+		}
+
+		try {
+			$mapping = $this->fileMapper->findByFileId($fileId);
+			if ($mapping !== null) {
+				$this->fileMapper->delete($mapping);
+			}
+		} catch (\Throwable $e) {
+			$this->logger->error(
+				'Failed to clean up Documenso mappings for file ' . $fileId . ': ' . $e->getMessage(),
+				['app' => Application::APP_ID, 'exception' => $e]
+			);
+		}
+	}
+}

--- a/lib/Migration/Version020300Date20260904124704.php
+++ b/lib/Migration/Version020300Date20260904124704.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Documenso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version020300Date20260904124704 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('documenso_files')) {
+			return null;
+		}
+
+		$table = $schema->getTable('documenso_files');
+		if ($table->hasColumn('status')) {
+			return null;
+		}
+
+		$table->addColumn('status', Types::STRING, [
+			'notnull' => true,
+			'length' => 32,
+			'default' => 'DRAFT',
+		]);
+
+		$table->addUniqueIndex(['file_id'], 'documenso_files_file_id');
+		return $schema;
+	}
+}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -74,64 +74,61 @@ class FileService {
 			? $document['status']
 			: '';
 
-		if ($status === 'REJECTED') {
-			$this->logger->info(
-				'Documenso document ' . $documentId . ' ended with status ' . $status,
-				['app' => Application::APP_ID]
-			);
-			$this->fileMapper->delete($mapping);
+		if ($status === '' || !in_array($status, DocumensoFile::STATUSES, true)) {
 			return;
 		}
 
-		if ($status !== 'COMPLETED') {
-			return;
-		}
+		$alreadyCompleted = $mapping->getStatus() === DocumensoFile::STATUS_COMPLETED;
 
-		$download = $this->apiService->downloadSignedDocument($userId, $documentId);
-		if (!isset($download['content'])) {
-			$this->logger->warning(
-				'Failed to download signed Documenso document ' . $documentId . ': ' . ($download['error'] ?? 'unknown error'),
-				['app' => Application::APP_ID]
-			);
-			return;
-		}
-
-		try {
-			$userFolder = $this->rootFolder->getUserFolder($userId);
-			$nodes = $userFolder->getById($fileId);
-			if ($nodes === []) {
-				throw new NotFoundException('File not found for id ' . $fileId);
+		if ($status === DocumensoFile::STATUS_COMPLETED && !$alreadyCompleted) {
+			$download = $this->apiService->downloadSignedDocument($userId, $documentId);
+			if (!isset($download['content'])) {
+				$this->logger->warning(
+					'Failed to download signed Documenso document ' . $documentId . ': ' . ($download['error'] ?? 'unknown error'),
+					['app' => Application::APP_ID]
+				);
+				return;
 			}
-			$node = $nodes[0];
-			if (!($node instanceof File)) {
-				throw new NotFoundException('Node is not a file for id ' . $fileId);
-			}
-			$node->putContent($download['content']);
 
-			// Create a notification for the user
-			$notification = $this->notificationManager->createNotification();
-			$notification->setApp(Application::APP_ID)
-				->setUser($userId)
-				->setDateTime(new \DateTime())
-				->setObject('document', (string)$documentId)
-				->setSubject('document_signed', [
-					'id' => $node->getId(),
-					'name' => $node->getName(),
-				]);
-			$this->notificationManager->notify($notification);
-		} catch (\Throwable $e) {
-			$this->logger->error(
-				'Failed to update Nextcloud file for Documenso document ' . $documentId . ': ' . $e->getMessage(),
-				['app' => Application::APP_ID, 'exception' => $e]
-			);
-			$this->fileMapper->delete($mapping);
-			return;
+			try {
+				$userFolder = $this->rootFolder->getUserFolder($userId);
+				$nodes = $userFolder->getById($fileId);
+				if ($nodes === []) {
+					throw new NotFoundException('File not found for id ' . $fileId);
+				}
+				$node = $nodes[0];
+				if (!($node instanceof File)) {
+					throw new NotFoundException('Node is not a file for id ' . $fileId);
+				}
+				$node->putContent($download['content']);
+
+				$notification = $this->notificationManager->createNotification();
+				$notification->setApp(Application::APP_ID)
+					->setUser($userId)
+					->setDateTime(new \DateTime())
+					->setObject('document', (string)$documentId)
+					->setSubject('document_signed', [
+						'id' => $node->getId(),
+						'name' => $node->getName(),
+					]);
+				$this->notificationManager->notify($notification);
+
+				$this->logger->info(
+					'Updated Nextcloud file ' . $fileId . ' from completed Documenso document ' . $documentId,
+					['app' => Application::APP_ID]
+				);
+			} catch (\Throwable $e) {
+				$this->logger->error(
+					'Failed to update Nextcloud file for Documenso document ' . $documentId . ': ' . $e->getMessage(),
+					['app' => Application::APP_ID, 'exception' => $e]
+				);
+				return;
+			}
 		}
 
-		$this->fileMapper->delete($mapping);
-		$this->logger->info(
-			'Updated Nextcloud file ' . $fileId . ' from completed Documenso document ' . $documentId,
-			['app' => Application::APP_ID]
-		);
+		if ($mapping->getStatus() !== $status) {
+			$mapping->setStatus($status);
+			$this->fileMapper->update($mapping);
+		}
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -24,5 +24,8 @@
 		<file name="tests/stubs/oc_hooks_emitter.php" />
         <file name="tests/stubs/oca_files_event.php" />
         <file name="tests/stubs/doctrine_dbal_schema_table.php" />
+		<file name="tests/stubs/oca_dav_events_sabrepluginaddevent.php" />
+		<file name="tests/stubs/oca_dav_connector_sabre.php" />
+		<file name="tests/stubs/sabre_dav.php" />
 	</stubs>
 </psalm>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -35,8 +35,8 @@
 			</NcTextField>
 			<NcNoteCard type="info">
 				<p>
-					<!-- TRANSLATORS document.completed is a Documenso webhook event name and must stay in English -->
-					{{ t('integration_documenso', 'To update signed files immediately instead of waiting for the next polling interval, create a webhook in Documenso under the "Webhooks" section. Make sure to select the "document.completed" event trigger and point it to this URL:') }}
+					<!-- TRANSLATORS document.sent, document.completed, document.rejected and document.cancelled are Documenso webhook event names and must stay in English -->
+					{{ t('integration_documenso', 'To update document status and signed files immediately instead of waiting for the next polling interval, create a webhook in Documenso under the "Webhooks" section. Make sure to select the "document.sent", "document.completed", "document.rejected" and "document.cancelled" event triggers and point it to this URL:') }}
 				</p>
 				<p class="webhook-value">
 					{{ state.webhook_url }}

--- a/src/files/init.js
+++ b/src/files/init.js
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { registerFileAction } from '@nextcloud/files'
+import { registerDavProperty } from '@nextcloud/files/dav'
+
+import { inlineStatusAction } from './inlineStatusAction.js'
+
+registerDavProperty('nc:documenso-state', { nc: 'http://nextcloud.org/ns' })
+registerFileAction(inlineStatusAction)

--- a/src/files/inlineStatusAction.js
+++ b/src/files/inlineStatusAction.js
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Permission } from '@nextcloud/files'
+
+import DraftIconSvg from '../../img/dash_draft.svg'
+import PendingIconSvg from '../../img/dash_pending.svg'
+import CompleteIconSvg from '../../img/dash_complete.svg'
+import RejectedIconSvg from '../../img/dash_rejected.svg'
+import CancelledIconSvg from '../../img/dash_cancelled.svg'
+
+const STATUSES = {
+	DRAFT: 'DRAFT',
+	PENDING: 'PENDING',
+	COMPLETED: 'COMPLETED',
+	REJECTED: 'REJECTED',
+	CANCELLED: 'CANCELLED',
+}
+
+const KNOWN_STATUSES = Object.values(STATUSES)
+
+/**
+ * @param {import('@nextcloud/files').Node[]} nodes File nodes from the Files app
+ * @return {string}
+ */
+function getStatus(nodes) {
+	if (nodes.length !== 1) {
+		return ''
+	}
+	return nodes[0].attributes['documenso-state'] ?? ''
+}
+
+export const inlineStatusAction = {
+	id: 'documenso-inline',
+	title: ({ nodes }) => {
+		const status = getStatus(nodes)
+		switch (status) {
+		case STATUSES.DRAFT:
+			return t('integration_documenso', 'Document is a draft in Documenso')
+		case STATUSES.PENDING:
+			return t('integration_documenso', 'Waiting for signatures in Documenso')
+		case STATUSES.COMPLETED:
+			return t('integration_documenso', 'Document was signed in Documenso')
+		case STATUSES.REJECTED:
+			return t('integration_documenso', 'Document was rejected in Documenso')
+		case STATUSES.CANCELLED:
+			return t('integration_documenso', 'Document was cancelled in Documenso')
+		default:
+			return ''
+		}
+	},
+	displayName: ({ nodes }) => {
+		const status = getStatus(nodes)
+		switch (status) {
+		case STATUSES.DRAFT:
+			return t('integration_documenso', 'Draft')
+		case STATUSES.PENDING:
+			return t('integration_documenso', 'Waiting for signatures')
+		case STATUSES.COMPLETED:
+			return t('integration_documenso', 'Completed')
+		case STATUSES.REJECTED:
+			return t('integration_documenso', 'Rejected')
+		case STATUSES.CANCELLED:
+			return t('integration_documenso', 'Cancelled')
+		default:
+			return ''
+		}
+	},
+	inline: () => true,
+	exec: async () => null,
+	order: -10,
+	iconSvgInline({ nodes }) {
+		const status = getStatus(nodes)
+		switch (status) {
+		case STATUSES.DRAFT:
+			return DraftIconSvg
+		case STATUSES.PENDING:
+			return PendingIconSvg
+		case STATUSES.COMPLETED:
+			return CompleteIconSvg
+		case STATUSES.REJECTED:
+			return RejectedIconSvg
+		case STATUSES.CANCELLED:
+			return CancelledIconSvg
+		default:
+			return PendingIconSvg
+		}
+	},
+	enabled({ nodes }) {
+		if (nodes.length !== 1) {
+			return false
+		}
+		const node = nodes[0]
+		const status = getStatus(nodes)
+		return (node.permissions & Permission.READ) !== 0
+			&& KNOWN_STATUSES.includes(status)
+	},
+}

--- a/tests/stubs/doctrine_dbal_schema_table.php
+++ b/tests/stubs/doctrine_dbal_schema_table.php
@@ -2,6 +2,10 @@
 
 namespace Doctrine\DBAL\Schema {
 	class Table {
+		public function hasColumn(string $name): bool {
+			return false;
+		}
+
 		/**
 		 * @param mixed[] $options
 		 * @return self

--- a/tests/stubs/oca_dav_connector_sabre.php
+++ b/tests/stubs/oca_dav_connector_sabre.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Connector\Sabre {
+	use Sabre\DAV\ICollection;
+	use Sabre\DAV\INode;
+
+	abstract class Node implements INode {
+		public function getId(): int {
+			return 0;
+		}
+
+		public function getPath(): string {
+			return '';
+		}
+	}
+
+	class Directory extends Node implements ICollection {
+		/**
+		 * @return list<Node>
+		 */
+		public function getChildren(): array {
+			return [];
+		}
+	}
+}

--- a/tests/stubs/oca_dav_events_sabrepluginaddevent.php
+++ b/tests/stubs/oca_dav_events_sabrepluginaddevent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Events;
+
+use OCP\EventDispatcher\Event;
+use Sabre\DAV\Server;
+
+/**
+ * This event is triggered during the setup of the SabreDAV server to allow the
+ * registration of additional plugins.
+ *
+ * @since 28.0.0
+ */
+class SabrePluginAddEvent extends Event {
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function __construct(
+		private Server $server,
+	) {
+	}
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getServer(): Server {
+	}
+}

--- a/tests/stubs/sabre_dav.php
+++ b/tests/stubs/sabre_dav.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Sabre\DAV {
+	interface INode {
+	}
+
+	interface ICollection extends INode {
+	}
+
+	class PropFind {
+		/**
+		 * @param string $key
+		 * @param mixed $valueOrCallable
+		 */
+		public function handle(string $key, $valueOrCallable): void {
+		}
+
+		public function getStatus(string $propertyName): ?int {
+			return null;
+		}
+	}
+
+	class Server {
+		public function on(string $eventName, callable $callable): void {
+		}
+
+		public function addPlugin(ServerPlugin $plugin): void {
+		}
+	}
+
+	class ServerPlugin {
+		public function initialize(Server $server): void {
+		}
+
+		public function getPluginName(): string {
+			return '';
+		}
+
+		/**
+		 * @return array{name: string, description: string}
+		 */
+		public function getPluginInfo(): array {
+			return [
+				'name' => '',
+				'description' => '',
+			];
+		}
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const appId = 'integration_documenso'
 webpackConfig.entry = {
 	adminSettings: { import: path.join(__dirname, 'src', 'personalSettings.js'), filename: appId + '-personalSettings.js' },
 	filesplugin: { import: path.join(__dirname, 'src', 'filesplugin.js'), filename: appId + '-filesplugin.js' },
+	init: { import: path.join(__dirname, 'src', 'files', 'init.js'), filename: appId + '-init.js' },
 }
 
 webpackConfig.plugins.push(


### PR DESCRIPTION
Stores the state of the flies in documenso so that it can be seen in files. Also now restricts files to only one pending documenso flow per file to make it less confusing. Uses the same icons as the dashboard except for some missing statuses. Depends on #170
<img width="2992" height="480" alt="image" src="https://github.com/user-attachments/assets/76cf9bdc-ee6a-4664-a03a-c8383a32a6b6" />

## 🤖 AI (if applicable)

- [X] The content of this PR was partly or fully generated using AI
